### PR TITLE
bugfix: 修复购物车页面刷新时底部导航消失的问题

### DIFF
--- a/pages/index/cart.vue
+++ b/pages/index/cart.vue
@@ -109,7 +109,10 @@
   import { computed, reactive } from 'vue';
   import { fen2yuan } from '@/sheep/hooks/useGoods';
   import { isEmpty } from '@/sheep/helper/utils';
-
+  
+  // 隐藏原生tabBar
+  uni.hideTabBar();
+  
   const sys_navBar = sheep.$platform.navbar;
   const cart = sheep.$store('cart');
 


### PR DESCRIPTION
不确定这么改是否合适，我不会前端，但这么改确实刷新时没问题了。