### PR TITLE
fix:修复分销提现页银行名称存储问题，兼容管理端回显

### DIFF
--- a/pages/commission/withdraw.vue
+++ b/pages/commission/withdraw.vue
@@ -115,7 +115,7 @@
         >
           <uni-easyinput
             :inputBorder="false"
-            :value="state.accountInfo.bankName"
+            :value="bankNameLabel"
             placeholder="请选择银行"
             suffixIcon="right"
             disabled
@@ -164,7 +164,7 @@
 </template>
 
 <script setup>
-  import { onBeforeMount, reactive } from 'vue';
+  import { onBeforeMount, reactive, computed } from 'vue';
   import sheep from '@/sheep';
   import accountTypeSelect from './components/account-type-select.vue';
   import { fen2yuan } from '@/sheep/hooks/useGoods';
@@ -197,6 +197,14 @@
     withdrawTypes: [], // 提现方式
     bankList: [], // 银行字典数据
     bankListSelectedIndex: '', // 选中银行 bankList 的 index
+  });
+
+  const bankNameLabel = computed(() => {
+    if (!state.accountInfo.bankName || !state.bankList || state.bankList.length === 0) {
+      return '';
+    }
+    const item = state.bankList.find((it) => it.value === state.accountInfo.bankName);
+    return item ? item.label : '';
   });
 
   // 打开提现方式的弹窗
@@ -300,7 +308,8 @@
   function bankChange(e) {
     const value = e.detail.value;
     state.bankListSelectedIndex = value;
-    state.accountInfo.bankName = state.bankList[value].label;
+    const item = state.bankList[value];
+    state.accountInfo.bankName = item ? item.value : undefined;
   }
 
   onBeforeMount(() => {


### PR DESCRIPTION
修改内容：佣金提现页
修改前：银行选择时向后端提交字典 label，导致管理端回显失败
<img width="1691" height="124" alt="image" src="https://github.com/user-attachments/assets/c2d0c86c-eee0-4c33-acb4-ac16ee455228" />
修改后：银行选择时改为向后端提交字典 value，并通过计算属性根据 value 显示对应银行 label
<img width="1631" height="329" alt="image" src="https://github.com/user-attachments/assets/58e9e6fa-d9f0-43c8-967b-f6a9991aa4c6" />
